### PR TITLE
Add spect integration tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8103,6 +8103,12 @@
             "integrity": "sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA==",
             "dev": true
         },
+        "spect": {
+            "version": "23.1.1",
+            "resolved": "https://registry.npmjs.org/spect/-/spect-23.1.1.tgz",
+            "integrity": "sha512-UHZKSpbedwiXnbc9Es7dCRsJf4n8iqs4IMBlSACbLUzmmIXkN2WicTCfDjqN0o+IFQAQtL3KnKmY3X8Qdxqefg==",
+            "dev": true
+        },
         "split": {
             "version": "0.3.3",
             "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
         "rxjs-for-await": "0.0.2",
         "sinon": "^11.1.2",
         "sinon-chai": "^3.7.0",
+        "spect": "^23.1.1",
         "ts-loader": "^9.2.6",
         "tsconfig-holy-grail": "^11.1.17",
         "tslint": "^6.1.3",

--- a/test/helpers/map.js
+++ b/test/helpers/map.js
@@ -1,0 +1,14 @@
+import { patch, toObserver } from 'rxjs-interop';
+import { createWrapSubscribeFunction } from '../../src/factories/wrap-subscribe-function';
+
+const wrapSubscribeFunction = createWrapSubscribeFunction(patch, toObserver);
+
+export const map = (observable, mapValue) =>
+    wrapSubscribeFunction(({ next, ...args }) => {
+        const { unsubscribe } = observable[Symbol.observable]().subscribe({
+            ...args,
+            next: (value) => next(mapValue(value))
+        });
+
+        return () => unsubscribe();
+    });

--- a/test/integration/animation-frame.js
+++ b/test/integration/animation-frame.js
@@ -5,6 +5,7 @@ import { first } from 'rxjs/operators';
 import { from } from 'rxjs';
 import { fromESObservable as fromESObservableBaconJs } from 'baconjs';
 import { fromESObservable as fromESObservableKefirJs } from 'kefir';
+import { h } from 'spect';
 import xs from 'xstream';
 
 describe('animationFrame', () => {
@@ -71,5 +72,26 @@ describe('animationFrame', () => {
 
             break;
         }
+    });
+
+    it('should work with spect', async () => {
+        const test = h`<div id="test">${animationFrame()}</div>`;
+
+        document.body.appendChild(test);
+
+        while (true) {
+            try {
+                expect(document.getElementById('test').textContent).to.match(/[1-9]\d+/);
+
+                break;
+            } catch {
+                await new Promise((resolve) => {
+                    setTimeout(resolve, 100);
+                });
+            }
+        }
+
+        document.body.removeChild(test);
+        test[Symbol.dispose]();
     });
 });

--- a/test/integration/geolocation.js
+++ b/test/integration/geolocation.js
@@ -5,6 +5,8 @@ import { from } from 'rxjs';
 import { fromESObservable as fromESObservableBaconJs } from 'baconjs';
 import { fromESObservable as fromESObservableKefirJs } from 'kefir';
 import { geolocation } from '../../src/module';
+import { h } from 'spect';
+import { map } from '../helpers/map';
 import xs from 'xstream';
 
 describe('geolocation', () => {
@@ -107,6 +109,30 @@ describe('geolocation', () => {
 
                 break;
             }
+        });
+
+        it('should work with spect', async () => {
+            const test = h`<div id="test">${map(
+                geolocation(),
+                ({ coords: { accuracy, latitude, longitude } }) => `${accuracy}-${latitude}-${longitude}`
+            )}</div>`;
+
+            document.body.appendChild(test);
+
+            while (true) {
+                try {
+                    expect(document.getElementById('test').textContent).to.equal('1-50-50');
+
+                    break;
+                } catch {
+                    await new Promise((resolve) => {
+                        setTimeout(resolve, 100);
+                    });
+                }
+            }
+
+            document.body.removeChild(test);
+            test[Symbol.dispose]();
         });
     }
 });

--- a/test/integration/intersections.js
+++ b/test/integration/intersections.js
@@ -4,7 +4,9 @@ import { first } from 'rxjs/operators';
 import { from } from 'rxjs';
 import { fromESObservable as fromESObservableBaconJs } from 'baconjs';
 import { fromESObservable as fromESObservableKefirJs } from 'kefir';
+import { h } from 'spect';
 import { intersections } from '../../src/module';
+import { map } from '../helpers/map';
 import xs from 'xstream';
 
 describe('intersections', () => {
@@ -87,5 +89,26 @@ describe('intersections', () => {
 
             break;
         }
+    });
+
+    it('should work with spect', async () => {
+        const test = h`<div id="test">${map(intersections(document.body), (entries) => entries.length)}</div>`;
+
+        document.body.appendChild(test);
+
+        while (true) {
+            try {
+                expect(document.getElementById('test').textContent).to.equal('1');
+
+                break;
+            } catch {
+                await new Promise((resolve) => {
+                    setTimeout(resolve, 100);
+                });
+            }
+        }
+
+        document.body.removeChild(test);
+        test[Symbol.dispose]();
     });
 });

--- a/test/integration/media-devices.js
+++ b/test/integration/media-devices.js
@@ -4,6 +4,8 @@ import { first } from 'rxjs/operators';
 import { from } from 'rxjs';
 import { fromESObservable as fromESObservableBaconJs } from 'baconjs';
 import { fromESObservable as fromESObservableKefirJs } from 'kefir';
+import { h } from 'spect';
+import { map } from '../helpers/map';
 import { mediaDevices } from '../../src/module';
 import xs from 'xstream';
 
@@ -156,4 +158,32 @@ describe('mediaDevices', () => {
             }
         }
     });
+
+    // eslint-disable-next-line no-undef
+    if (!process.env.CI || !navigator.userAgent.includes('Firefox')) {
+        it('should work with spect', async () => {
+            const test = h`<div id="test">${map(mediaDevices(), (mediaDeviceInfos) =>
+                mediaDeviceInfos.map(({ kind }) => kind).join(',')
+            )}</div>`;
+
+            document.body.appendChild(test);
+
+            while (true) {
+                try {
+                    expect(document.getElementById('test').textContent).to.match(
+                        /(?:audioinput|audiooutput|videoinput)(?:,(?:audioinput|audiooutput|videoinput))*/
+                    );
+
+                    break;
+                } catch {
+                    await new Promise((resolve) => {
+                        setTimeout(resolve, 100);
+                    });
+                }
+            }
+
+            document.body.removeChild(test);
+            test[Symbol.dispose]();
+        });
+    }
 });

--- a/test/integration/media-query-match.js
+++ b/test/integration/media-query-match.js
@@ -4,6 +4,7 @@ import { first } from 'rxjs/operators';
 import { from } from 'rxjs';
 import { fromESObservable as fromESObservableBaconJs } from 'baconjs';
 import { fromESObservable as fromESObservableKefirJs } from 'kefir';
+import { h } from 'spect';
 import { mediaQueryMatch } from '../../src/module';
 import xs from 'xstream';
 
@@ -71,5 +72,26 @@ describe('mediaQueryMatch', () => {
 
             break;
         }
+    });
+
+    it('should work with spect', async () => {
+        const test = h`<div id="test">${mediaQueryMatch('(max-width:600px)')}</div>`;
+
+        document.body.appendChild(test);
+
+        while (true) {
+            try {
+                expect(document.getElementById('test').textContent).to.equal('false');
+
+                break;
+            } catch {
+                await new Promise((resolve) => {
+                    setTimeout(resolve, 100);
+                });
+            }
+        }
+
+        document.body.removeChild(test);
+        test[Symbol.dispose]();
     });
 });

--- a/test/integration/metrics.js
+++ b/test/integration/metrics.js
@@ -4,6 +4,8 @@ import { first } from 'rxjs/operators';
 import { from } from 'rxjs';
 import { fromESObservable as fromESObservableBaconJs } from 'baconjs';
 import { fromESObservable as fromESObservableKefirJs } from 'kefir';
+import { h } from 'spect';
+import { map } from '../helpers/map';
 import { metrics } from '../../src/module';
 import xs from 'xstream';
 
@@ -109,5 +111,26 @@ describe('metrics', () => {
 
             break;
         }
+    });
+
+    it('should work with spect', async () => {
+        const test = h`<div id="test">${map(metrics({ type: 'mark' }), (entries) => entries.map(({ name }) => name).join(','))}</div>`;
+
+        document.body.appendChild(test);
+
+        while (true) {
+            try {
+                expect(document.getElementById('test').textContent).to.equal('a fake name');
+
+                break;
+            } catch {
+                await new Promise((resolve) => {
+                    setTimeout(resolve, 100);
+                });
+            }
+        }
+
+        document.body.removeChild(test);
+        test[Symbol.dispose]();
     });
 });

--- a/test/integration/midi-inputs.js
+++ b/test/integration/midi-inputs.js
@@ -4,6 +4,8 @@ import { first } from 'rxjs/operators';
 import { from } from 'rxjs';
 import { fromESObservable as fromESObservableBaconJs } from 'baconjs';
 import { fromESObservable as fromESObservableKefirJs } from 'kefir';
+import { h } from 'spect';
+import { map } from '../helpers/map';
 import { midiInputs } from '../../src/module';
 import xs from 'xstream';
 
@@ -116,6 +118,29 @@ describe('midiInputs()', () => {
 
                 break;
             }
+        });
+
+        it('should work with spect', async () => {
+            const test = h`<div id="test">${map(midiInputs(midiAccess), (midiInputsArray) =>
+                midiInputsArray.map(({ name }) => name).join(',')
+            )}</div>`;
+
+            document.body.appendChild(test);
+
+            while (true) {
+                try {
+                    expect(document.getElementById('test').textContent).to.equal('Virtual Input Device');
+
+                    break;
+                } catch {
+                    await new Promise((resolve) => {
+                        setTimeout(resolve, 100);
+                    });
+                }
+            }
+
+            document.body.removeChild(test);
+            test[Symbol.dispose]();
         });
     }
 });

--- a/test/integration/midi-outputs.js
+++ b/test/integration/midi-outputs.js
@@ -4,6 +4,8 @@ import { first } from 'rxjs/operators';
 import { from } from 'rxjs';
 import { fromESObservable as fromESObservableBaconJs } from 'baconjs';
 import { fromESObservable as fromESObservableKefirJs } from 'kefir';
+import { h } from 'spect';
+import { map } from '../helpers/map';
 import { midiOutputs } from '../../src/module';
 import xs from 'xstream';
 
@@ -116,6 +118,29 @@ describe('midiOutputs()', () => {
 
                 break;
             }
+        });
+
+        it('should work with spect', async () => {
+            const test = h`<div id="test">${map(midiOutputs(midiAccess), (midiInputsArray) =>
+                midiInputsArray.map(({ name }) => name).join(',')
+            )}</div>`;
+
+            document.body.appendChild(test);
+
+            while (true) {
+                try {
+                    expect(document.getElementById('test').textContent).to.equal('Virtual Output Device');
+
+                    break;
+                } catch {
+                    await new Promise((resolve) => {
+                        setTimeout(resolve, 100);
+                    });
+                }
+            }
+
+            document.body.removeChild(test);
+            test[Symbol.dispose]();
         });
     }
 });

--- a/test/integration/mutations.js
+++ b/test/integration/mutations.js
@@ -4,6 +4,8 @@ import { first } from 'rxjs/operators';
 import { from } from 'rxjs';
 import { fromESObservable as fromESObservableBaconJs } from 'baconjs';
 import { fromESObservable as fromESObservableKefirJs } from 'kefir';
+import { h } from 'spect';
+import { map } from '../helpers/map';
 import { mutations } from '../../src/module';
 import xs from 'xstream';
 
@@ -87,5 +89,28 @@ describe('mutations', () => {
 
             break;
         }
+    });
+
+    it('should work with spect', async () => {
+        const test = h`<div id="test">${map(mutations(document.body, { childList: true }), (records) =>
+            records.map(({ target }) => target.nodeName).join(',')
+        )}</div>`;
+
+        document.body.appendChild(test);
+
+        while (true) {
+            try {
+                expect(document.getElementById('test').textContent).to.equal('BODY');
+
+                break;
+            } catch {
+                await new Promise((resolve) => {
+                    setTimeout(resolve, 100);
+                });
+            }
+        }
+
+        document.body.removeChild(test);
+        test[Symbol.dispose]();
     });
 });

--- a/test/integration/on.js
+++ b/test/integration/on.js
@@ -4,6 +4,8 @@ import { first } from 'rxjs/operators';
 import { from } from 'rxjs';
 import { fromESObservable as fromESObservableBaconJs } from 'baconjs';
 import { fromESObservable as fromESObservableKefirJs } from 'kefir';
+import { h } from 'spect';
+import { map } from '../helpers/map';
 import { on } from '../../src/module';
 import xs from 'xstream';
 
@@ -81,5 +83,26 @@ describe('on', () => {
 
             break;
         }
+    });
+
+    it('should work with spect', async () => {
+        const test = h`<div id="test">${map(on(htmlElement, 'click'), ({ target }) => target.nodeName)}</div>`;
+
+        document.body.appendChild(test);
+
+        while (true) {
+            try {
+                expect(document.getElementById('test').textContent).to.equal('A');
+
+                break;
+            } catch {
+                await new Promise((resolve) => {
+                    setTimeout(resolve, 100);
+                });
+            }
+        }
+
+        document.body.removeChild(test);
+        test[Symbol.dispose]();
     });
 });

--- a/test/integration/online.js
+++ b/test/integration/online.js
@@ -4,6 +4,7 @@ import { first } from 'rxjs/operators';
 import { from } from 'rxjs';
 import { fromESObservable as fromESObservableBaconJs } from 'baconjs';
 import { fromESObservable as fromESObservableKefirJs } from 'kefir';
+import { h } from 'spect';
 import { online } from '../../src/module';
 import xs from 'xstream';
 
@@ -71,5 +72,26 @@ describe('online', () => {
 
             break;
         }
+    });
+
+    it('should work with spect', async () => {
+        const test = h`<div id="test">${online()}</div>`;
+
+        document.body.appendChild(test);
+
+        while (true) {
+            try {
+                expect(document.getElementById('test').textContent).to.equal('true');
+
+                break;
+            } catch {
+                await new Promise((resolve) => {
+                    setTimeout(resolve, 100);
+                });
+            }
+        }
+
+        document.body.removeChild(test);
+        test[Symbol.dispose]();
     });
 });

--- a/test/integration/permission-state.js
+++ b/test/integration/permission-state.js
@@ -4,6 +4,7 @@ import { first } from 'rxjs/operators';
 import { from } from 'rxjs';
 import { fromESObservable as fromESObservableBaconJs } from 'baconjs';
 import { fromESObservable as fromESObservableKefirJs } from 'kefir';
+import { h } from 'spect';
 import { permissionState } from '../../src/module';
 import xs from 'xstream';
 
@@ -126,4 +127,27 @@ describe('permissionState', () => {
             }
         }
     });
+
+    if (navigator.permissions !== undefined) {
+        it('should work with spect', async () => {
+            const test = h`<div id="test">${permissionState({ name: 'notifications' })}</div>`;
+
+            document.body.appendChild(test);
+
+            while (true) {
+                try {
+                    expect(document.getElementById('test').textContent).to.equal('prompt');
+
+                    break;
+                } catch {
+                    await new Promise((resolve) => {
+                        setTimeout(resolve, 100);
+                    });
+                }
+            }
+
+            document.body.removeChild(test);
+            test[Symbol.dispose]();
+        });
+    }
 });

--- a/test/integration/reports.js
+++ b/test/integration/reports.js
@@ -4,6 +4,8 @@ import { first } from 'rxjs/operators';
 import { from } from 'rxjs';
 import { fromESObservable as fromESObservableBaconJs } from 'baconjs';
 import { fromESObservable as fromESObservableKefirJs } from 'kefir';
+import { h } from 'spect';
+import { map } from '../helpers/map';
 import { reports } from '../../src/module';
 import xs from 'xstream';
 
@@ -138,4 +140,29 @@ describe('reports', () => {
             }
         }
     });
+
+    if (window.ReportingObserver !== undefined) {
+        it('should work with spect', async () => {
+            const test = h`<div id="test">${map(reports({ buffered: true }), (reportList) =>
+                reportList.map(({ type }) => type).join(',')
+            )}</div>`;
+
+            document.body.appendChild(test);
+
+            while (true) {
+                try {
+                    expect(document.getElementById('test').textContent).to.equal('intervention');
+
+                    break;
+                } catch {
+                    await new Promise((resolve) => {
+                        setTimeout(resolve, 100);
+                    });
+                }
+            }
+
+            document.body.removeChild(test);
+            test[Symbol.dispose]();
+        });
+    }
 });

--- a/test/integration/resizes.js
+++ b/test/integration/resizes.js
@@ -4,6 +4,8 @@ import { first } from 'rxjs/operators';
 import { from } from 'rxjs';
 import { fromESObservable as fromESObservableBaconJs } from 'baconjs';
 import { fromESObservable as fromESObservableKefirJs } from 'kefir';
+import { h } from 'spect';
+import { map } from '../helpers/map';
 import { resizes } from '../../src/module';
 import xs from 'xstream';
 
@@ -87,5 +89,28 @@ describe('resizes', () => {
 
             break;
         }
+    });
+
+    it('should work with spect', async () => {
+        const test = h`<div id="test">${map(resizes(htmlElement), (entries) =>
+            entries.map(({ target }) => target.nodeName).join(',')
+        )}</div>`;
+
+        document.body.appendChild(test);
+
+        while (true) {
+            try {
+                expect(document.getElementById('test').textContent).to.equal('DIV');
+
+                break;
+            } catch {
+                await new Promise((resolve) => {
+                    setTimeout(resolve, 100);
+                });
+            }
+        }
+
+        document.body.removeChild(test);
+        test[Symbol.dispose]();
     });
 });

--- a/test/integration/unhandled-rejections.js
+++ b/test/integration/unhandled-rejections.js
@@ -4,6 +4,8 @@ import { first } from 'rxjs/operators';
 import { from } from 'rxjs';
 import { fromESObservable as fromESObservableBaconJs } from 'baconjs';
 import { fromESObservable as fromESObservableKefirJs } from 'kefir';
+import { h } from 'spect';
+import { map } from '../helpers/map';
 import { unhandledRejection } from '../../src/module';
 import xs from 'xstream';
 
@@ -79,5 +81,26 @@ describe('unhandledRejection', () => {
 
             break;
         }
+    });
+
+    it('should work with spect', async () => {
+        const test = h`<div id="test">${map(unhandledRejection(100), ({ message }) => message)}</div>`;
+
+        document.body.appendChild(test);
+
+        while (true) {
+            try {
+                expect(document.getElementById('test').textContent).to.equal('a fake error');
+
+                break;
+            } catch {
+                await new Promise((resolve) => {
+                    setTimeout(resolve, 100);
+                });
+            }
+        }
+
+        document.body.removeChild(test);
+        test[Symbol.dispose]();
     });
 });

--- a/test/integration/video-frame.js
+++ b/test/integration/video-frame.js
@@ -4,6 +4,8 @@ import { first } from 'rxjs/operators';
 import { from } from 'rxjs';
 import { fromESObservable as fromESObservableBaconJs } from 'baconjs';
 import { fromESObservable as fromESObservableKefirJs } from 'kefir';
+import { h } from 'spect';
+import { map } from '../helpers/map';
 import { videoFrame } from '../../src/module';
 import xs from 'xstream';
 
@@ -191,4 +193,27 @@ describe('videoFrame', () => {
             }
         }
     });
+
+    if (HTMLVideoElement.prototype.requestVideoFrameCallback !== undefined) {
+        it('should work with spect', async () => {
+            const test = h`<div id="test">${map(videoFrame(videoElement), ({ height, width }) => `${height}x${width}`)}</div>`;
+
+            document.body.appendChild(test);
+
+            while (true) {
+                try {
+                    expect(document.getElementById('test').textContent).to.equal('100x100');
+
+                    break;
+                } catch {
+                    await new Promise((resolve) => {
+                        setTimeout(resolve, 100);
+                    });
+                }
+            }
+
+            document.body.removeChild(test);
+            test[Symbol.dispose]();
+        });
+    }
 });

--- a/test/integration/wake-lock.js
+++ b/test/integration/wake-lock.js
@@ -4,6 +4,7 @@ import { first } from 'rxjs/operators';
 import { from } from 'rxjs';
 import { fromESObservable as fromESObservableBaconJs } from 'baconjs';
 import { fromESObservable as fromESObservableKefirJs } from 'kefir';
+import { h } from 'spect';
 import { wakeLock } from '../../src/module';
 import xs from 'xstream';
 
@@ -138,4 +139,27 @@ describe('wakeLock', () => {
             }
         }
     });
+
+    if (navigator.wakeLock !== undefined) {
+        it('should work with spect', async () => {
+            const test = h`<div id="test">${wakeLock('screen')}</div>`;
+
+            document.body.appendChild(test);
+
+            while (true) {
+                try {
+                    expect(document.getElementById('test').textContent).to.equal('true');
+
+                    break;
+                } catch {
+                    await new Promise((resolve) => {
+                        setTimeout(resolve, 100);
+                    });
+                }
+            }
+
+            document.body.removeChild(test);
+            test[Symbol.dispose]();
+        });
+    }
 });


### PR DESCRIPTION
Hi @dy, could you please take a look if that looks correct? If so I would continue adding an integration test for each subscribable thing.

One thing I noticed is that calling `[Symbol.dispose]()` doesn't call `unsubscribe()` on the underlying observable. Should I open a separate issue for that on [spectjs/spec](https://github.com/spectjs/spec)?